### PR TITLE
Update aznum2words.go

### DIFF
--- a/aznum2words.go
+++ b/aznum2words.go
@@ -90,9 +90,9 @@ var floatingPointDict = map[int]string{
 	10_000_000_000_000:  "on trilyonda",
 	100_000_000_000_000: "yüz trilyonda",
 
-	1_000_000_000_000_000:   "bir katrilyonda",
-	10_000_000_000_000_000:  "on katrilyonda",
-	100_000_000_000_000_000: "yüz katrilyonda",
+	1_000_000_000_000_000:   "bir kvadrilyonda",
+	10_000_000_000_000_000:  "on kvadrilyonda",
+	100_000_000_000_000_000: "yüz kvadrilyonda",
 }
 
 var digits = []string{

--- a/aznum2words.go
+++ b/aznum2words.go
@@ -42,8 +42,8 @@ const (
 	MillionAsString         string = "milyon"         // 10^6
 	BillionAsString         string = "milyard"        // 10^9
 	TrillionAsString        string = "trilyon"        // 10^12
-	QuadrillionAsString     string = "katrilyon"      // 10^15
-	QuintillionAsString     string = "kentilyon"      // 10^18
+	QuadrillionAsString     string = "kvadrilyon"     // 10^15
+	QuintillionAsString     string = "kvintilyon"     // 10^18
 	SextillionAsString      string = "sekstilyon"     // 10^21
 	SeptillionAsString      string = "septilyon"      // 10^24
 	OctillionAsString       string = "oktilyon"       // 10^27

--- a/aznum2words_test.go
+++ b/aznum2words_test.go
@@ -1112,7 +1112,7 @@ func testCaseSpellNumberForPositiveIntegerNumbers() []testCaseSpellNumber {
 		testCaseSpellNumber{
 			description: testCaseDescription,
 			given:       "493882371553121860890561055192142938414552660618128252927700430053",
-			expected:    "dörd yüz doxsan üç vigintilyon səkkiz yüz səksən iki novemdesilyon üç yüz yetmiş bir oktodesilyon beş yüz əlli üç septendesilyon bir yüz iyirmi bir seksdesilyon səkkiz yüz altmış kendesilyon səkkiz yüz doxsan katordesilyon beş yüz altmış bir tredesilyon əlli beş dodesilyon bir yüz doxsan iki undesilyon bir yüz qırx iki desilyon doqquz yüz otuz səkkiz nonilyon dörd yüz on dörd oktilyon beş yüz əlli iki septilyon altı yüz altmış sekstilyon altı yüz on səkkiz kentilyon bir yüz iyirmi səkkiz katrilyon iki yüz əlli iki trilyon doqquz yüz iyirmi yeddi milyard yeddi yüz milyon dörd yüz otuz min əlli üç",
+			expected:    "dörd yüz doxsan üç vigintilyon səkkiz yüz səksən iki novemdesilyon üç yüz yetmiş bir oktodesilyon beş yüz əlli üç septendesilyon bir yüz iyirmi bir seksdesilyon səkkiz yüz altmış kendesilyon səkkiz yüz doxsan katordesilyon beş yüz altmış bir tredesilyon əlli beş dodesilyon bir yüz doxsan iki undesilyon bir yüz qırx iki desilyon doqquz yüz otuz səkkiz nonilyon dörd yüz on dörd oktilyon beş yüz əlli iki septilyon altı yüz altmış sekstilyon altı yüz on səkkiz kvintilyon bir yüz iyirmi səkkiz kvadrilyon iki yüz əlli iki trilyon doqquz yüz iyirmi yeddi milyard yeddi yüz milyon dörd yüz otuz min əlli üç",
 		},
 	}
 }


### PR DESCRIPTION
orthographic corrections fixed for QuadrillionAsString and QuintillionAsString. Referred to personal experience as well as orpho  dictionaries  https://www.azleks.az/ and https://obastan.com/"