### PR TITLE
Reduce mem alloc, after pprof

### DIFF
--- a/aznum2words.go
+++ b/aznum2words.go
@@ -88,7 +88,7 @@ func SpellNumber(numberAsStr string) (string, error) {
 // handleIntegerNumberConversion("-79594") -> "mənfi yetmiş doqquz min beş yüz doxsan dörd"
 // handleIntegerNumberConversion("81") -> "səksən bir"
 func handleIntegerNumberConversion(intValueAsStr string) (string, error) {
-	wordBuilder := make([]string, 0)
+	var builder strings.Builder
 
 	signKeyword, err := getSignSymbolAsWord(intValueAsStr)
 	if err != nil {
@@ -96,20 +96,24 @@ func handleIntegerNumberConversion(intValueAsStr string) (string, error) {
 	}
 
 	if signKeyword != "" {
-		wordBuilder = append(wordBuilder, signKeyword)
+		builder.WriteString(signKeyword)
+		builder.WriteString(" ")
 	}
 
 	intValueWithoutSign := removeSignMarkIfExists(intValueAsStr)
-	spelledInteger := convertIntPart(intValueWithoutSign)
+	spelledInteger, err := convertIntPart(intValueWithoutSign)
+	if err != nil {
+		return "", err
+	}
 
 	// handling case: intValueAsStr is '-0'
 	if intValueWithoutSign == "0" {
 		return spelledInteger, nil
 	}
 
-	wordBuilder = append(wordBuilder, spelledInteger)
+	builder.WriteString(spelledInteger)
 
-	return strings.Join(wordBuilder, " "), nil
+	return builder.String(), nil
 }
 
 // The function intended to handle the conversion of floating point numbers into words
@@ -124,7 +128,10 @@ func handleFloatingPointNumberConversion(floatValueAsStr string) (string, error)
 	floatValueAsStr = removeSignMarkIfExists(floatValueAsStr)
 	slices := strings.Split(floatValueAsStr, DecimalPointSeparator)
 
-	intPartAsWord := convertIntPart(slices[0])
+	intPartAsWord, err := convertIntPart(slices[0])
+	if err != nil {
+		return "", err
+	}
 
 	floatingPart := slices[1]
 
@@ -139,7 +146,11 @@ func handleFloatingPointNumberConversion(floatValueAsStr string) (string, error)
 	var floatingPartAsIntegerWithWord string
 	var suffix string
 	if len(floatingPart) != 0 {
-		floatingPartAsIntegerWithWord = convertIntPart(floatingPart)
+		floatingPartAsIntegerWithWord, err = convertIntPart(floatingPart)
+		if err != nil {
+			return "", err
+		}
+
 		cnt := len(floatingPart)
 		separatorKey := int(math.Pow10(cnt))
 		resultSuffix, ok := floatingPointDict[separatorKey]

--- a/converters_test.go
+++ b/converters_test.go
@@ -10,7 +10,10 @@ import (
 func Test_convertIntPart_WhereTwoDigitsNumber(t *testing.T) {
 	twoDigitsCases := fixtures.ConvertIntPartsForTwoDigitsNumbers()
 	for _, testcase := range twoDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testcase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testcase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testcase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testcase.Expected) {
 			t.Errorf("For %s "+
@@ -28,8 +31,10 @@ func Test_convertIntPart_WhereTwoDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereSingleDigitsNumber(t *testing.T) {
 	singleDigitsCases := fixtures.ConvertIntPartsForSingleDigitsNumbers()
 	for _, testCase := range singleDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
-
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			t.Errorf("For %s "+
 				"\n Given: %d, len: %d "+
@@ -46,7 +51,10 @@ func Test_convertIntPart_WhereSingleDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereThreeDigitsNumber(t *testing.T) {
 	threeDigitsCases := fixtures.ConvertIntPartsForThreeDigitsNumbers()
 	for _, testCase := range threeDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			//t.Error("For", testCase.Description,
@@ -69,7 +77,10 @@ func Test_convertIntPart_WhereThreeDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereFourDigitsNumber(t *testing.T) {
 	fourDigitsCases := fixtures.ConvertIntPartsForFourDigitsNumbers()
 	for _, testCase := range fourDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			//t.Error("For", testCase.Description,
@@ -92,7 +103,10 @@ func Test_convertIntPart_WhereFourDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereFiveDigitsNumber(t *testing.T) {
 	fiveDigitsCases := fixtures.ConvertIntPartsForFiveDigitsNumbers()
 	for _, testCase := range fiveDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			//t.Error("For", testCase.Description,
@@ -115,7 +129,10 @@ func Test_convertIntPart_WhereFiveDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereSixDigitsNumber(t *testing.T) {
 	sixDigitsCases := fixtures.ConvertIntPartsForSixDigitsNumbers()
 	for _, testCase := range sixDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			//t.Error("For", testCase.Description,
@@ -138,7 +155,10 @@ func Test_convertIntPart_WhereSixDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereSevenDigitsNumber(t *testing.T) {
 	sevenDigitsCases := fixtures.ConvertIntPartsForSevenDigitsNumbers()
 	for _, testCase := range sevenDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			//t.Error("For", testCase.Description,
@@ -161,7 +181,10 @@ func Test_convertIntPart_WhereSevenDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereEightDigitsNumber(t *testing.T) {
 	eightDigitsCases := fixtures.ConvertIntPartsForEightDigitsNumbers()
 	for _, testCase := range eightDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			//t.Error("For", testCase.Description,
@@ -184,7 +207,10 @@ func Test_convertIntPart_WhereEightDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereNineDigitsNumber(t *testing.T) {
 	nineDigitsCases := fixtures.ConvertIntPartsForNineDigitsNumbers()
 	for _, testCase := range nineDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			//t.Error("For", testCase.Description,
@@ -207,7 +233,10 @@ func Test_convertIntPart_WhereNineDigitsNumber(t *testing.T) {
 func Test_convertIntPart_WhereTenDigitsNumber(t *testing.T) {
 	tenDigitsCases := fixtures.ConvertIntPartsForTenDigitsNumbers()
 	for _, testCase := range tenDigitsCases {
-		actual := convertIntPart(strconv.Itoa(testCase.Given))
+		actual, err := convertIntPart(strconv.Itoa(testCase.Given))
+		if err != nil {
+			t.Errorf("For %s, err: %v", testCase.Description, err)
+		}
 
 		if !reflect.DeepEqual(actual, testCase.Expected) {
 			//t.Error("For", testCase.Description,


### PR DESCRIPTION
Armed with **pprof data**, I have applied the following changes:
1. Replace String Slices with `strings.Builder`
Fix: Eliminated textBuilder and wordBuilder slices, using strings.Builder to build strings incrementally.
Impact: Removed multiple append allocations _(e.g., 2.5MB in convertIntPart)_ and strings.Join overhead (e.g., 6.5MB cumulatively).

2. Eliminate String Concatenation
Fix: Replaced + with `builder.WriteString` calls.
Impact: Cut allocations from concatenation _(e.g., 0.9MB in convertThreeDigitsIntoWord)_.[](url)